### PR TITLE
{% dfp_footer %} tries to include "dfp/dfp_footer.html"

### DIFF
--- a/dfp/templatetags/dfp_tags.py
+++ b/dfp/templatetags/dfp_tags.py
@@ -9,7 +9,7 @@ register = template.Library()
 
 @register.simple_tag(takes_context=True)
 def dfp_footer(context):
-    t = template.loader.get_template('dfp/dfp_footer.html')
+    t = template.loader.select_template(['dfp/dfp_footer.html', 'basic/dfp/dfp_footer.html'])
     c = template.Context({})
     return t.render(c)
 


### PR DESCRIPTION
The only template included is in basic/dfp/dfp_footer.html. Instead of moving the template out of basic, changed the get_template call to select_template and had it look in both places.
